### PR TITLE
Add docker compose for robot simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,29 +58,13 @@ ssh robot
 
 # Simulating the robot
 
-```bash
-docker run -it \
-    --network="host" \
-    --pid="host" \
-    --ipc="host" \
-    frankjoshua/ros2-bridge-suite
-```
+The simulation containers can be launched using docker compose.
 
 ```bash
-docker run -it \
-    --network="host" \
-    --pid="host" \
-    --ipc="host" \
-    frankjoshua/ros2-diff-drive-controller
+./start_simulation.sh
 ```
 
-```bash
-docker run -it \
-    --network="host" \
-    --pid="host" \
-    --ipc="host" \
-    frankjoshua/ros2-urdf
-```
+This script starts the services defined in `docker-compose-simulation.yml`.
 
 # Links
 

--- a/docker-compose-simulation.yml
+++ b/docker-compose-simulation.yml
@@ -1,0 +1,24 @@
+# docker-compose-simulation.yml
+version: '3'
+
+services:
+  ros2_bridge_suite:
+    container_name: ros2_bridge_suite
+    image: frankjoshua/ros2-bridge-suite
+    network_mode: host
+    ipc: host
+    pid: host
+
+  ros2_diff_drive_controller:
+    container_name: ros2_diff_drive_controller
+    image: frankjoshua/ros2-diff-drive-controller
+    network_mode: host
+    ipc: host
+    pid: host
+
+  ros2_urdf:
+    container_name: ros2_urdf
+    image: frankjoshua/ros2-urdf
+    network_mode: host
+    ipc: host
+    pid: host

--- a/start_simulation.sh
+++ b/start_simulation.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose -f docker-compose-simulation.yml up


### PR DESCRIPTION
## Summary
- add a Docker Compose file for running the bridge suite, diff-drive controller and URDF
- provide a helper script to launch the simulation stack
- update simulation instructions in the README

## Testing
- `bash tests/run_tests.sh` *(fails: unrecognized arguments --nagios --hosts=default --ssh-config=ssh-config)*

------
https://chatgpt.com/codex/tasks/task_e_684c86c11c54832083e21d4aa3d6a9a0