### PR TITLE
Update start_simulation script to start entire stack

### DIFF
--- a/start_simulation.sh
+++ b/start_simulation.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
 
+# Start tooling containers in the background
+export PUID=$(id -u)
+export PGID=$(id -g)
+docker compose -f docker-compose-tools.yml up -d
+
+# Start ROS containers required for simulation
+docker compose -f docker-compose-ros.yml up -d
+
+# Launch the simulation stack in the foreground
 docker compose -f docker-compose-simulation.yml up


### PR DESCRIPTION
## Summary
- launch tools, ROS, and simulation services from `start_simulation.sh`

## Testing
- `pip install pytest testinfra`
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c8a1eaae8832082e156ac4c6e8539